### PR TITLE
use fleek join instead of fleek init

### DIFF
--- a/src/pages/docs/multiple.md
+++ b/src/pages/docs/multiple.md
@@ -85,7 +85,7 @@ See [Installation](/docs/installation) for instructions on how to install Nix.
 
 It is not necessary to install Fleek directly on the new computer. We'll use Nix to run Fleek without installing it, so it can be self-managed.
 
-### Run `fleek init`
+### Run `fleek join`
 
 {% callout type="warning" title="Tip: Test Git First" %}
 Make sure your new computer is configured for Git before trying this. See [Configuring Git](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup) for more information.


### PR DESCRIPTION
When adding a new computer, the instructions are to use `fleek join`. The title of the chapter mentions `fleek init`.
When I first went through this process, I've used `fleek init` before `fleek join`, and that was an issue as `fleek join` failed because of existing files. I propose to change the title from `fleek init` to `fleek join` to avoid this confusion.